### PR TITLE
Upgrade Go version to 1.20

### DIFF
--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -44,7 +44,7 @@ resource "google_storage_bucket_object" "bot" {
 resource "google_cloudfunctions_function" "bot_webhook" {
   name        = "BotWebhookHandler"
   description = "Handle LINE Bot webhook"
-  runtime     = "go119"
+  runtime     = "go120"
 
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.bot.name

--- a/func/bot/go.mod
+++ b/func/bot/go.mod
@@ -1,6 +1,6 @@
 module github.com/raahii/haraiai/func/bot
 
-go 1.19
+go 1.20
 
 replace github.com/raahii/haraiai/pkg => ../../pkg
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/raahii/haraiai/pkg
 
-go 1.19
+go 1.20
 
 replace github.com/raahii/haraiai/pkg => ../../pkg
 

--- a/tool/develop/go.mod
+++ b/tool/develop/go.mod
@@ -1,6 +1,6 @@
 module github.com/raahii/haraiai/tool/develop
 
-go 1.18
+go 1.20
 
 replace github.com/raahii/haraiai/pkg => ../../pkg
 


### PR DESCRIPTION
## Changes
1.19 → 1.20

[Go ランタイム  |  Google Cloud Functions に関するドキュメント](https://cloud.google.com/functions/docs/concepts/go-runtime?hl=ja)