### PR TITLE
Support pay amount text including comma etc

### DIFF
--- a/pkg/messaging/handler/bot_message.go
+++ b/pkg/messaging/handler/bot_message.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	PAYMENT_TEXT_TRIM_CHARS = []string{",", "\\", "円", "￥", "¥", " "}
+	PAYMENT_TEXT_REMOVE_STRS = []string{",", "\\", "円", "￥", "¥", " "}
 
 	MESSAGES_FOR_NAME_CHANGE_GUIDE = []string{
 		"名前変更",
@@ -637,8 +637,8 @@ func parsePaymentTitle(text string) string {
 }
 
 func parsePayAmount(text string) (int, error) {
-	for _, c := range PAYMENT_TEXT_TRIM_CHARS {
-		text = strings.ReplaceAll(text, string(c), "")
+	for _, s := range PAYMENT_TEXT_REMOVE_STRS {
+		text = strings.ReplaceAll(text, s, "")
 	}
 
 	value, err := strconv.Atoi(text)

--- a/pkg/messaging/handler/bot_message.go
+++ b/pkg/messaging/handler/bot_message.go
@@ -40,6 +40,8 @@ const (
 )
 
 var (
+	PAYMENT_TEXT_TRIM_CHARS = []string{",", "\\", "円", "￥", "¥", " "}
+
 	MESSAGES_FOR_NAME_CHANGE_GUIDE = []string{
 		"名前変更",
 		"ニックネーム変更",
@@ -635,9 +637,11 @@ func parsePaymentTitle(text string) string {
 }
 
 func parsePayAmount(text string) (int, error) {
-	trimmed := strings.Trim(text, " \n\\¥円")
+	for _, c := range PAYMENT_TEXT_TRIM_CHARS {
+		text = strings.ReplaceAll(text, string(c), "")
+	}
 
-	value, err := strconv.Atoi(trimmed)
+	value, err := strconv.Atoi(text)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to parse '%s' as integer: %w", text, err)
 	}


### PR DESCRIPTION
下記のようなメッセージでも支払いのテキストとして受け付けるようにする
```
スタバ
2,000円
```

