### PR TITLE
Stop creating rich menu by server API

### DIFF
--- a/pkg/messaging/handler/bot.go
+++ b/pkg/messaging/handler/bot.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/line/line-bot-sdk-go/v7/linebot"
@@ -26,12 +25,6 @@ func ProvideBotHandler(
 	s store.Store,
 ) (BotHandler, error) {
 	handler := &BotHandlerImpl{config: c, bot: b, fs: f, store: s}
-
-	err := handler.createRichMenu()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create rich menu: %w", err)
-	}
-
 	return handler, nil
 }
 


### PR DESCRIPTION
## Background
9/17 0時頃より急にharaiaiが応答しなくなった。

```
failed to create rich menu: SDK CreateRichMenu method returns error: linebot: APIError 400 max #of richmenu (1000) reached
at github.com/raahii/haraiai/func/bot.init.0 ( /workspace/serverless_function_source_code/bot.go:18 )
```

リッチメニューを設定する意図でCreate Rich Menu APIを使っていたが、リッチメニューを作成するAPIであって上限の1000件に到達した模様。
https://developers.line.biz/ja/reference/messaging-api/#create-rich-menu

## Change
リッチメニューの作成をしないようにする。